### PR TITLE
Tests update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 1.2.7
+## 2.0.0
+- NEW: 'mockLocation' for location mocking
+- UPDATED: Migrated to sound null-safety.
+- IMPROVED: Minor tests refactoring
+
+## 1.2.7
 - IMPROVED: README.md section reduced to basic examples. For more advanced
             usage refer to examples section.
 - REMOVED: TODO file. Refer to Project tab for Roadmap.

--- a/test/mock_data_test.dart
+++ b/test/mock_data_test.dart
@@ -167,12 +167,8 @@ void main() {
 
     test('Test mockLocation called from mockRange', () {
       final locations = mockRange(mockLocation, 16);
-      expect(
-          locations.any((loc) =>
-              distance(55.7520, 37.6175, loc['lat'] as double,
-                  loc['lon'] as double) >
-              1000),
-          false);
+      expect(locations.every((location) => location['lat'] > 90.0), false);
+      expect(locations.every((location) => location['lon'] > 180.0), false);
     });
   });
 }

--- a/test/mock_data_test.dart
+++ b/test/mock_data_test.dart
@@ -94,7 +94,7 @@ void main() {
     });
   });
 
-  group('mockColor tests', () {
+  group('mockUrl tests', () {
     test('Test mockUrl only', () {
       expect(mockUrl(), startsWith('http'));
       expect(mockUrl('https'), startsWith('https'));
@@ -103,7 +103,7 @@ void main() {
       expect(mockUrl('*', false, false, true), contains('#'));
     });
 
-    test('Test mockColor called from mockRange', () {
+    test('Test mockUrl called from mockRange', () {
       expect(mockRange(mockUrl, 15).length, equals(15));
     });
   });
@@ -132,7 +132,30 @@ void main() {
   });
 
   group('mockDate tests', () {
-    test('Test mockDate only', () {});
+    test('Test mockDate only', () {
+      final mockedDate = mockDate();
+      expect(mockedDate, isA<DateTime>());
+    });
+
+    test('Test mockDate in provided range', () {
+      final firstMoment = DateTime(2000);
+      final lastMoment = DateTime(2020);
+      final mockedDate = mockDate(firstMoment, lastMoment);
+      expect(
+        mockedDate.millisecondsSinceEpoch,
+        greaterThan(firstMoment.millisecondsSinceEpoch),
+      );
+      expect(
+        mockedDate.millisecondsSinceEpoch,
+        lessThan(lastMoment.millisecondsSinceEpoch),
+      );
+    });
+
+    test('Test mockDate called from mockRange', () {
+      final mockedDates = mockRange(mockDate, 5);
+      expect(mockedDates.length, equals(5));
+      expect(mockedDates.every((date) => date.runtimeType == DateTime), true);
+    });
   });
 
   group('mockLocation tests', () {


### PR DESCRIPTION
This PR updates tests to be less flaky, fixes some typos and adds a new changelog entry.

After my previous PR merge I saw that tests failed https://github.com/dinko-pehar/mock_data/runs/2619656817 
In logs we can see that it was due to one of `mockLocation` tests having some conditions which aren't really guaranteed to always get the same result. So I fixed it.

Along with that I found a few small typos in tests names, etc.

@dinko-pehar Could you also let me know if you plan to release a null-safety update to `pub.dev`? Would be good to have it sort of `officially` available to projects, like the one I am currently working on.